### PR TITLE
히스토리 Modal 구현 

### DIFF
--- a/src/modals/HistoryModal/HistoryModal.jsx
+++ b/src/modals/HistoryModal/HistoryModal.jsx
@@ -1,11 +1,24 @@
 import ModalHeader from "../components/ModalHeader";
+import ModalButton from "../components/ModalButton";
+import HistoryInfo from "./components/HistoryInfo";
 import "../../styles/modals/HistoryModal/HistoryModal.css";
 
 const HistoryModal = () => {
   return (
     <div className="modal modal-responsive-height modal-history-height">
       <ModalHeader title="히스토리" />
-      히스토리모달입니다
+      <div className="modal-history">
+        <div className="history-title">
+          총&nbsp;<span>32</span>개의 히스토리
+          <ModalButton variant="outLine-default" size="sm" contents="전체 삭제" />
+        </div>
+        <div className="history-wrapper">
+          <HistoryInfo />
+          <HistoryInfo />
+          <HistoryInfo />
+          <HistoryInfo />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/modals/HistoryModal/components/HistoryInfo.jsx
+++ b/src/modals/HistoryModal/components/HistoryInfo.jsx
@@ -1,0 +1,18 @@
+import "../../../styles/modals/HistoryModal/components/HistoryInfo.css";
+
+const HistoryInfo = () => {
+  const test = "pending";
+
+  return (
+    <div className="hisotry-info">
+      <div className={`history-status ${test}`} />
+      <div className="history-info-wrapper">
+        <div className="history-info-title">타이틀 부분</div>
+        <div className="history-info-content">설명 부분</div>
+        <div className="history-info-date">날짜 부분</div>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryInfo;

--- a/src/styles/modals/DetailModal/DetailModal.css
+++ b/src/styles/modals/DetailModal/DetailModal.css
@@ -20,26 +20,6 @@
   margin-top: 0.8125rem;
 }
 
-.pending {
-  background-color: #d9d9d9;
-}
-
-.important_urgent {
-  background-color: #fdebec;
-}
-
-.important_not_urgent {
-  background-color: #f6f3f9;
-}
-
-.not_important_urgent {
-  background-color: #e7f3f8;
-}
-
-.not_important_not_urgent {
-  background-color: #edf3ec;
-}
-
 .detail-text {
   color: #393939;
   font-weight: 700;

--- a/src/styles/modals/HistoryModal/HistoryModal.css
+++ b/src/styles/modals/HistoryModal/HistoryModal.css
@@ -1,3 +1,32 @@
 .modal-history-height {
   max-height: 786px;
 }
+
+.modal-history {
+  padding: 1.0625rem 0.9375rem 5.625rem 0.9375rem;
+  height: calc(100% - 3.8rem);
+}
+
+.history-title {
+  display: flex;
+  font-weight: 500;
+  color: #393939;
+  font-size: 0.875rem;
+  align-items: center;
+}
+
+.history-title span {
+  font-weight: 700;
+}
+
+.history-title button {
+  width: 4.125rem;
+  height: 1.5625rem;
+  margin-left: auto;
+}
+
+.history-wrapper {
+  margin-top: 1.1875rem;
+  height: 30.375rem;
+  overflow-y: auto;
+}

--- a/src/styles/modals/HistoryModal/components/HistoryInfo.css
+++ b/src/styles/modals/HistoryModal/components/HistoryInfo.css
@@ -1,0 +1,40 @@
+.hisotry-info {
+  height: 6.75rem;
+  width: 100%;
+  border: 0.3px solid #e6e6e6;
+  display: flex;
+  margin-bottom: 0.5625rem;
+  border-radius: 8px;
+}
+
+.history-status {
+  height: 100%;
+  width: 1rem;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.history-info-wrapper {
+  padding: 0.6875rem 0px 0px 0.875rem;
+}
+
+.history-info-title {
+  font-weight: 600;
+  color: #464646;
+  font-size: 1.375rem;
+  height: 2.125rem;
+}
+
+.history-info-content {
+  font-weight: 500;
+  color: #656565;
+  font-size: 0.75rem;
+  height: 1.625rem;
+}
+
+.history-info-date {
+  font-weight: 500;
+  color: #656565;
+  font-size: 0.625rem;
+  height: 0.6875rem;
+}

--- a/src/styles/modals/ModalContainer.css
+++ b/src/styles/modals/ModalContainer.css
@@ -36,6 +36,26 @@
   overflow-y: auto;
 }
 
+.pending {
+  background-color: #d9d9d9;
+}
+
+.important_urgent {
+  background-color: #fdebec;
+}
+
+.important_not_urgent {
+  background-color: #f6f3f9;
+}
+
+.not_important_urgent {
+  background-color: #e7f3f8;
+}
+
+.not_important_not_urgent {
+  background-color: #edf3ec;
+}
+
 @keyframes fade-in {
   0% {
     opacity: 0;


### PR DESCRIPTION
### 📃 작업 내용

- 히스토리에 추가된 일정 정보를 보여주는 HistoryModal 구현
- 하나의 일정 정보를 보여주는 히스토리 정보 컴포넌트 구현
- Modal에서 사용되는 일정 유형에 따른 색상 변경 코드 ModalContainer.css에 추가

### 😎 PR 타입

- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- main <- feature/history-modal

### ❕ 참고 사항

- 히스토리 정보 일정 개수 이상 시 히스토리 정보만 위아래로 이동하는 수직 스크롤 생성

### 👀 미리보기
![히스토리 ](https://github.com/kihyaa/ei-planner-client/assets/127086869/531c177f-9175-4db8-824f-e74fbdede697)
