### PR TITLE
:sparkles: 블록 위치 서버 동기화 오류 해결

### DIFF
--- a/src/main/Main.jsx
+++ b/src/main/Main.jsx
@@ -6,6 +6,7 @@ import {
   MouseSensor,
   PointerSensor,
   TouchSensor,
+  pointerWithin,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -22,6 +23,7 @@ const Main = () => {
   const { task, setTask, getTaskById } = useTaskStore();
   const [items, setItems] = useState(null);
   const [activeId, setActiveId] = useState(null);
+  const [blockPos, setBlockPos] = useState(null);
   
   useEffect(()=>{
     getTask();
@@ -74,7 +76,9 @@ const Main = () => {
   );
 
   const handleDragStart = ({ active }) => {
+    const startContainer = active.data.current.sortable.containerId;
     setActiveId(active.id);
+    setBlockPos(startContainer);
   };
 
   const handleDragCancel = () => {
@@ -164,9 +168,15 @@ const Main = () => {
           );
         }
         const extractTaskIds = extractIdsByCategory(newItems, overContainer);
-        updatePosition(active.id, overContainer, extractTaskIds);
+        updatePosition(active.id, overContainer.toUpperCase(), extractTaskIds);
         return newItems;
       });
+    } else{
+      const endContainer = active.data.current.sortable.containerId;
+      if(blockPos !== endContainer){
+        const newItems = active.data.current.sortable.items;
+        updatePosition(active.id, endContainer.toUpperCase(), newItems);
+      }
     }
 
     setActiveId(null);
@@ -188,7 +198,6 @@ const Main = () => {
           Authorization: `Bearer ${localStorage.getItem("token")}`,
         },
       });
-      console.log(res);
     } catch (error) {
       alert("위치 갱신 실패. 다시 시도해주세요");
       console.error(error.message);
@@ -204,7 +213,8 @@ const Main = () => {
             onDragStart={handleDragStart}
             onDragCancel={handleDragCancel}
             onDragOver={handleDragOver}
-            onDragEnd={handleDragEnd}>
+            onDragEnd={handleDragEnd}
+            collisionDetection={pointerWithin}>
             {items && 
               <>
                 <Todo key="pending" id="pending" items={items} activeId={activeId} />


### PR DESCRIPTION
### 📃 작업 내용
- collisionDetection을 pointerWithin으로 변경
- droppalbe 영역의 key 값을 upperCase로 변경
- drag 시작 시 handleDragStart 함수에서 선택된 블록의 container.id를 blockPos에 저장
- dnd 동작 중 droppable 영역이 변경되었으나 id 값이 동일한 오류에 대해 조건부 처리
- id가 동일한 경우 blockPos와 도착한 영역의 id 값이 동일하지 않을 경우 영역에 대한 변경이라 판단하여 해당 정보를 서버와 동기화

### 😎 PR 타입

- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- main <- feature/main

### ❕ 참고 사항
- 

### 👀 미리보기
- 